### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,6 +23,6 @@ Documentation is published at http://xtraceback.rtfd.org/.
     :target: https://pypi.python.org/pypi/xtraceback/
     :alt: Latest Version
 
-.. image:: https://pypip.in/license/xtraceback/badge.png
+.. image:: https://img.shields.io/pypi/l/xtraceback.svg
     :target: https://github.com/0compute/makeenv/blob/master/LICENSE
     :alt: License


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20xtraceback))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `xtraceback`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.